### PR TITLE
Fix creation of namespace that becomes a dot

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,8 +58,7 @@ function promptAndSave(args: any, templatetype: string) {
 
             projectrootdir = removeTrailingSeparator(projectrootdir);
 
-            const newroot = projectrootdir.substr(projectrootdir.lastIndexOf(path.sep) + 1);
-            const filenamechildpath = newfilepath.substring(newfilepath.lastIndexOf(newroot));
+            const filenamechildpath = newfilepath.substr(projectrootdir.lastIndexOf(path.sep) + 1);
             const pathSepRegEx = os.platform() === "win32" ? /\\/g : /\//g;
             const namespace = path.dirname(filenamechildpath)
                 .replace(pathSepRegEx, '.')


### PR DESCRIPTION
Fixing issue #5 

Problem:
The newroot variable stored the name of the root folder / namespace, however when a file
with the same name of this namespace was created, the filenamechildpath variable instruction took
just the file name.

Solution:
Get the namespace path from the projectrootdir path, and then in the statement
of the namespace variable mount the full namespace from the path obtained by filenamechildpath,
just as it was already done in the code. This solution maintains compatibility with classes of different names
namespace and fixes the problem in the namespace name that becomes a dot for a class with the same name
of the current namespace.