### PR TITLE
Prevent extension search for .tmpl file popup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,9 +89,9 @@ async function openTemplateAndSaveNewFile(type: string, namespace: string, filen
     const templateFilePath = path.join(extension.extensionPath, 'templates', templatefileName);
 
     try {
-        const doc = await vscode.workspace.openTextDocument(templateFilePath);
+        const doc = await fs.readFile(templateFilePath, 'utf-8');
 
-        let text = doc.getText()
+        let text = doc
             .replace('${namespace}', namespace)
             .replace('${classname}', filename);
 


### PR DESCRIPTION
Steps to reproduce the issue:
1. Select `New C# Class` (or any option that uses the `openTemplateAndSaveNewFile` function)
1. This popup will appear:
![The Marketplace has extensions that can help with '.tmpl' files](https://user-images.githubusercontent.com/1327533/100481113-80bd2e00-30f3-11eb-8c2f-9cae61c132ab.png)

After the patch this won't happen (the diff a bit misleading because I had to move the error checking to the top).