### PR TITLE
Use file-scoped namespace in .NET 6.0+ projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "If created classes should include default namespaces"
+                },
+                "csharpextensions.useFileScopedNamespace": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use file scoped namespace in .NET 6.0+ projects"
                 }
             }
         }

--- a/src/csprojReader.ts
+++ b/src/csprojReader.ts
@@ -42,4 +42,31 @@ export default class CsprojReader implements Nameable {
 
         return;
     }
+
+    public async getTargetFramework(): Promise<string | undefined> {
+        try {
+            const result = await this.xmlParser.parseStringPromise(this.xml);
+
+            if (result === undefined
+                || result.Project.PropertyGroup === undefined
+                || !result.Project.PropertyGroup.length) {
+                return;
+            }
+
+            let foundFramework = undefined;
+
+            for (const propertyGroup of result.Project.PropertyGroup) {
+                if (propertyGroup.TargetFramework) {
+                    foundFramework = propertyGroup.TargetFramework[0];
+                    break;
+                }
+            }
+
+            return foundFramework;
+        } catch (errParsingXml) {
+            console.error('Error parsing project xml', errParsingXml);
+        }
+
+        return;
+    }
 }

--- a/src/fileScopedNamespaceConverter.ts
+++ b/src/fileScopedNamespaceConverter.ts
@@ -33,7 +33,8 @@ export class FileScopedNamespaceConverter {
         }
 
         const csprojFile = csprojs[0];
-        const fileContent =  await (await workspace.openTextDocument(Uri.file(csprojFile))).getText();
+        const csprojDocument =  await workspace.openTextDocument(Uri.file(csprojFile))
+        const fileContent = csprojDocument.getText();
         const projectReader = new CsprojReader(fileContent);
         const targetFramework = await projectReader.getTargetFramework();
 

--- a/src/fileScopedNamespaceConverter.ts
+++ b/src/fileScopedNamespaceConverter.ts
@@ -1,0 +1,86 @@
+import CsprojReader from './csprojReader';
+import { Uri, workspace } from 'vscode';
+import * as path from 'path';
+import * as findupglob from 'find-up-glob';
+
+export class FileScopedNamespaceConverter {
+    /**
+     * If the file to be created is a C# file, 
+     * and the TargetFramework version of the current project is .NET 6.0+, 
+     * and this feature is enabled in settings, 
+     * then return the file-scoped namespace form of the template. 
+     * 
+     * Else return the original template.
+     * 
+     * @param template The content of the C# template file.
+     * @param filePath The path of the C# file that is being created. Used to locate the .csproj file and get the TargetFramework version.
+     */
+
+    public async getFileScopedNamespaceFormOfTemplateIfNecessary(template: string, filePath: string): Promise<string> {
+        const useFileScopedNamespace = 
+            workspace.getConfiguration().get<boolean>('csharpextensions.useFileScopedNamespace', false) &&
+            filePath.endsWith('.cs') &&
+            await this.targetFrameworkHigherThanOrEqualToDotNet6(filePath);
+
+        return useFileScopedNamespace ? this.getFileScopedNamespaceFormOfTemplate(template) : template;
+    }
+
+    private async targetFrameworkHigherThanOrEqualToDotNet6(filePath: string): Promise<boolean> {
+        const csprojs: string[] = await findupglob('*.csproj', { cwd: path.dirname(filePath) });
+
+        if (csprojs === null || csprojs.length < 1) {
+            return false;
+        }
+
+        const csprojFile = csprojs[0];
+        const fileContent =  await (await workspace.openTextDocument(Uri.file(csprojFile))).getText();
+        const projectReader = new CsprojReader(fileContent);
+        const targetFramework = await projectReader.getTargetFramework();
+
+        if (targetFramework === undefined) {
+            return false;
+        }
+        
+        const versionString = targetFramework.match(/(?<=net)\d+(\.\d+)*/i); // Match .NET version string like "net6.0"
+
+        if (versionString === null) {
+            return false;
+        }
+
+        const version = +versionString[0];
+
+        return version >= 6;
+    }
+
+    /**
+     * Get the file-scoped namespace form of the template.
+     * 
+     * From:
+     * ```csharp
+     * namespace ${namespace}
+     * {
+     *    // Template content
+     *    // Template content
+     * }
+     * ```
+     * 
+     * To:
+     * ```csharp
+     * namespace ${namespace};
+     * 
+     * // Template content
+     * // Template content
+     * ```
+     * 
+     * @param template The content of the C# template file.
+     */
+    private getFileScopedNamespaceFormOfTemplate(template: string): string {
+        const result = template
+            .replace(new RegExp(/(?<=^)({|}| {4})/, 'gm'), '')
+            .replace(new RegExp(/(?<=\${namespace})/), ';');
+
+        return result;
+    }
+}
+
+export default new FileScopedNamespaceConverter();

--- a/src/template/template.ts
+++ b/src/template/template.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { sortBy, uniq } from 'lodash';
 
 import NamespaceDetector from '../namespaceDetector';
+import fileScopedNamespaceConverter from '../fileScopedNamespaceConverter';
 
 export default abstract class Template {
     private _name: string;
@@ -51,7 +52,11 @@ export default abstract class Template {
             const doc = await fs.readFile(templatePath, 'utf-8');
             const namespace = await this.getNamespace(filePath);
 
-            let text = doc
+            let text = doc;
+
+            text = await fileScopedNamespaceConverter.getFileScopedNamespaceFormOfTemplateIfNecessary(text, filePath);
+
+            text = text
                 .replace(Template.NamespaceRegex, namespace)
                 .replace(Template.ClassnameRegex, filename)
                 .replace('${namespaces}', this.getUsings());


### PR DESCRIPTION
Use C# 10's [file-scoped namespace](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces) when:
- The file to be created is a C# file
- The TargetFramework version of the current project is .NET 6.0+
- `csharpextensions.useFileScopedNamespace` is enabled in settings